### PR TITLE
fix torchac compilation with PyTorch >=1.2 and gcc10 ( #5 )

### DIFF
--- a/src/torchac/setup.py
+++ b/src/torchac/setup.py
@@ -103,7 +103,8 @@ def _supported_compilers_available():
 
 def _supported_gcc_available():
     v = _get_version(['gcc', '-v'], r'version (.*?)\s+')
-    return LooseVersion('6.0') > LooseVersion(v) >= LooseVersion('5.0'), v
+    return ((LooseVersion('6.0') > LooseVersion(v) >= LooseVersion('5.0')) or
+             LooseVersion(v) >= '10.0', v)
 
 
 def supported_nvcc_available():

--- a/src/torchac/torchac_backend/torchac.cpp
+++ b/src/torchac/torchac_backend/torchac.cpp
@@ -130,9 +130,9 @@ public:
 /** Get an instance of the `cdf_ptr` struct. */
 const struct cdf_ptr get_cdf_ptr(const at::Tensor& cdf)
 {
-    AT_CHECK(!cdf.is_cuda(), "cdf must be on CPU!")
+    TORCH_CHECK(!cdf.is_cuda(), "cdf must be on CPU!")
     const auto s = cdf.sizes();
-    AT_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for cdf! Expected 1HWLp")
+    TORCH_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for cdf! Expected 1HWLp")
 
     const int N_sym = s[1] * s[2];
     const int Lp = s[3];
@@ -239,10 +239,10 @@ py::bytes encode_logistic_mixture(
 {
     const int Lp = targets.sizes()[0];
     const auto s = means.sizes();
-    AT_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for means! Expected 1KHW")
-    AT_CHECK(means.sizes() == log_scales.sizes(), "Invalid size for log_scales! Expected 1KHW")
-    AT_CHECK(means.sizes() == logit_probs_softmax.sizes(), "Invalid size for logit_probs_softmax! Expected 1KHW")
-    AT_CHECK(means.is_cuda() && log_scales.is_cuda() && logit_probs_softmax.is_cuda(), "Tensors must be on CUDA!")
+    TORCH_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for means! Expected 1KHW")
+    TORCH_CHECK(means.sizes() == log_scales.sizes(), "Invalid size for log_scales! Expected 1KHW")
+    TORCH_CHECK(means.sizes() == logit_probs_softmax.sizes(), "Invalid size for logit_probs_softmax! Expected 1KHW")
+    TORCH_CHECK(means.is_cuda() && log_scales.is_cuda() && logit_probs_softmax.is_cuda(), "Tensors must be on CUDA!")
     const int N_sym = s[2] * s[3];
     const int K = s[1];
 
@@ -391,10 +391,10 @@ at::Tensor decode_logistic_mixture(
 {
     const int Lp = targets.sizes()[0];
     const auto s = means.sizes();
-    AT_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for means! Expected 1KHW")
-    AT_CHECK(means.sizes() == log_scales.sizes(), "Invalid size for log_scales! Expected 1KHW")
-    AT_CHECK(means.sizes() == logit_probs_softmax.sizes(), "Invalid size for logit_probs_softmax! Expected 1KHW")
-    AT_CHECK(means.is_cuda() && log_scales.is_cuda() && logit_probs_softmax.is_cuda(), "Tensors must be on CUDA!")
+    TORCH_CHECK(s.size() == 4 && s[0] == 1, "Invalid size for means! Expected 1KHW")
+    TORCH_CHECK(means.sizes() == log_scales.sizes(), "Invalid size for log_scales! Expected 1KHW")
+    TORCH_CHECK(means.sizes() == logit_probs_softmax.sizes(), "Invalid size for logit_probs_softmax! Expected 1KHW")
+    TORCH_CHECK(means.is_cuda() && log_scales.is_cuda() && logit_probs_softmax.is_cuda(), "Tensors must be on CUDA!")
     const int N_sym = s[2] * s[3];
     const int K = s[1];
 

--- a/src/torchac/torchac_backend/torchac_kernel.cu
+++ b/src/torchac/torchac_backend/torchac_kernel.cu
@@ -96,10 +96,10 @@ std::string to_string(const T& object) {
     return ss.str();
 }
 
-#define CHECK_1KHW(K, x) AT_CHECK(x.sizes().size() == 4 && x.sizes()[0] == 1 && x.sizes()[1] == K,  \
+#define CHECK_1KHW(K, x) TORCH_CHECK(x.sizes().size() == 4 && x.sizes()[0] == 1 && x.sizes()[1] == K,  \
         "#x must be 4D, got %s", to_string(x.sizes()))
 
-#define CHECK_CONTIGUOUS_AND_CUDA(x) AT_CHECK(x.is_contiguous() && x.is_cuda(), \
+#define CHECK_CONTIGUOUS_AND_CUDA(x) TORCH_CHECK(x.is_contiguous() && x.is_cuda(), \
         "#x must be contiguous and on GPU, got %d and %d", x.is_contiguous(), x.is_cuda())
 
 void calculate_cdf(
@@ -119,12 +119,12 @@ void calculate_cdf(
     CHECK_CONTIGUOUS_AND_CUDA(log_scales);
     CHECK_CONTIGUOUS_AND_CUDA(logit_probs_softmax);
 
-    AT_CHECK(means.sizes() == log_scales.sizes() &&
+    TORCH_CHECK(means.sizes() == log_scales.sizes() &&
              log_scales.sizes() == logit_probs_softmax.sizes())
 
     const auto param_sizes = means.sizes();
     const auto N = param_sizes[2] * param_sizes[3];  // H * W
-    AT_CHECK(N == N_cdf, "%d != %d", N, N_cdf);
+    TORCH_CHECK(N == N_cdf, "%d != %d", N, N_cdf);
 
     const int blockSize = 1024;
     const int numBlocks = (N * Lp + blockSize - 1) / blockSize;


### PR DESCRIPTION
Allow compilation with PyTorch >=1.2 (testing with 1.6) and GCC 10.
This partially addresses #5 
I am currently testing this on Arch Linux ( https://aur.archlinux.org/packages/python-pytorch-torchac/ ), will report back later.